### PR TITLE
Pass the name of the next step to the `onLeaving` and `onLeft` methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### 1.0.1
 
+Changed:    `onLeaving()` and `onLeft()` functions now take the `$nextStepName` as a parameter.
+
+### 1.0.1
+
 Added:      To allow for methods to be called before changing a step - `onLeaving()` and `onLeft()` methods to `Step`.
 `beforeChangeStep()`, `afterChangeStep()`, `createSteps()` to Wizard. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 1.0.1
+### 1.0.2
 
 Changed:    `onLeaving()` and `onLeft()` functions now take the `$nextStepName` as a parameter.
 

--- a/src/Step.php
+++ b/src/Step.php
@@ -46,12 +46,12 @@ abstract class Step extends Leaf
         $this->model->setStepData($stepData);
     }
 
-    public function onLeaving()
+    public function onLeaving($nextStepName)
     {
 
     }
 
-    public function onLeft()
+    public function onLeft($nextStepName)
     {
 
     }

--- a/src/Step.php
+++ b/src/Step.php
@@ -46,12 +46,12 @@ abstract class Step extends Leaf
         $this->model->setStepData($stepData);
     }
 
-    public function onLeaving($nextStepName)
+    public function onLeaving($targetStepName)
     {
 
     }
 
-    public function onLeft($nextStepName)
+    public function onLeft($targetStepName)
     {
 
     }

--- a/src/Wizard.php
+++ b/src/Wizard.php
@@ -152,13 +152,13 @@ abstract class Wizard extends Leaf
     /**
      * Allows methods to be executed before changeStep
      *
-     * @param $stepName
+     * @param $currentStepName
      * @return mixed
      */
-    final function beforeChangeStep($stepName)
+    final function beforeChangeStep($currentStepName, $nextStepName)
     {
         $steps = $this->getSteps();
-        return $steps[$stepName]->onLeaving();
+        return $steps[$currentStepName]->onLeaving($nextStepName);
     }
 
     /**
@@ -170,10 +170,10 @@ abstract class Wizard extends Leaf
      */
     private function changeStep($stepName)
     {
-        $currentStep = $this->model->currentStepName;
+        $currentStepName = $this->model->currentStepName;
         try {
-            if ($currentStep) {
-                $this->beforeChangeStep($currentStep);
+            if ($currentStepName) {
+                $this->beforeChangeStep($currentStepName, $stepName);
             }
         } catch (AbortChangeStepException $exception) {
             return;
@@ -190,8 +190,8 @@ abstract class Wizard extends Leaf
 
         $this->model->currentStepName = $stepName;
 
-        if ($currentStep) {
-            $this->afterChangeStep($this->model->currentStepName);
+        if ($currentStepName) {
+            $this->afterChangeStep($currentStepName, $stepName);
         }
 
     }
@@ -199,12 +199,12 @@ abstract class Wizard extends Leaf
     /**
      * Allows methods to be executed after changeStep
      *
-     * @param $stepName
+     * @param $currentStepName
      */
-    final function afterChangeStep($stepName)
+    final function afterChangeStep($currentStepName, $nextStepName)
     {
         $steps = $this->getSteps();
-        $steps[$stepName]->onLeft();
+        $steps[$currentStepName]->onLeft($nextStepName);
     }
 
     /**

--- a/src/Wizard.php
+++ b/src/Wizard.php
@@ -153,12 +153,13 @@ abstract class Wizard extends Leaf
      * Allows methods to be executed before changeStep
      *
      * @param $currentStepName
+     * @param $targetStepName
      * @return mixed
      */
-    final function beforeChangeStep($currentStepName, $nextStepName)
+    final function beforeChangeStep($currentStepName, $targetStepName)
     {
         $steps = $this->getSteps();
-        return $steps[$currentStepName]->onLeaving($nextStepName);
+        return $steps[$currentStepName]->onLeaving($targetStepName);
     }
 
     /**
@@ -200,11 +201,12 @@ abstract class Wizard extends Leaf
      * Allows methods to be executed after changeStep
      *
      * @param $currentStepName
+     * @param $targetStepName
      */
-    final function afterChangeStep($currentStepName, $nextStepName)
+    final function afterChangeStep($currentStepName, $targetStepName)
     {
         $steps = $this->getSteps();
-        $steps[$currentStepName]->onLeft($nextStepName);
+        $steps[$currentStepName]->onLeft($targetStepName);
     }
 
     /**


### PR DESCRIPTION
This allows validation to occur only when needed. For example, it can be bypassed when going back a step.