### PR TITLE
Make step data public

### DIFF
--- a/src/StepModel.php
+++ b/src/StepModel.php
@@ -14,7 +14,7 @@ class StepModel extends LeafModel
      */
     public $navigateToStepEvent;
 
-    private $stepData;
+    public $stepData;
 
     public function __construct()
     {


### PR DESCRIPTION
Making step data public will allow it to be accessed where required, rather than setting up and raising events to get the data.